### PR TITLE
Hifiberry digi settings

### DIFF
--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -57,7 +57,7 @@ class AudioConfigHandler(ZynthianConfigHandler):
 		}],
 		['HifiBerry Digi', {
 			'SOUNDCARD_CONFIG':'dtoverlay=hifiberry-digi',
-			'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:sndrpihifiberry -r 44100 -p 256 -n 2 -X raw'
+			'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:sndrpihifiberry -r 44100 -p 256 -n 2 -X raw -S'
 		}],
 		['HifiBerry Amp', {
 			'SOUNDCARD_CONFIG': 'dtoverlay=hifiberry-amp',

--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -57,7 +57,7 @@ class AudioConfigHandler(ZynthianConfigHandler):
 		}],
 		['HifiBerry Digi', {
 			'SOUNDCARD_CONFIG':'dtoverlay=hifiberry-digi',
-			'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:0 -r 44100 -p 256 -n 2 -X raw'
+			'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:sndrpihifiberry -r 44100 -p 256 -n 2 -X raw'
 		}],
 		['HifiBerry Amp', {
 			'SOUNDCARD_CONFIG': 'dtoverlay=hifiberry-amp',


### PR DESCRIPTION
# Use HW name instead of device number

* I've had a problem where if the audio services restart, USB devices with audio cards in them such as my Roland piano are initialised at hw:0. If we use the device name we ensure jackd connects to the correct ALSA device.

# Jack should configure card for 16-bit samples

* Explicitly tell jack to initialise a Hifiberry Digi device 16-bit with **-S** parameter to stop it auto initialise to 32-bit
* This prevents wildly distorted audio as it tries to play raw audio at the wrong rate
* I noticed this break in the change from Stretch to Buster ZynthianOS images