### PR TITLE
Add jackd alsa paramater for Hifiberry Digi playback only

### DIFF
--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -57,7 +57,7 @@ class AudioConfigHandler(ZynthianConfigHandler):
 		}],
 		['HifiBerry Digi', {
 			'SOUNDCARD_CONFIG':'dtoverlay=hifiberry-digi',
-			'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:sndrpihifiberry -S -r 44100 -p 256 -n 2 -X raw'
+			'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:sndrpihifiberry -P -S -r 44100 -p 256 -n 2 -X raw'
 		}],
 		['HifiBerry Amp', {
 			'SOUNDCARD_CONFIG': 'dtoverlay=hifiberry-amp',


### PR DESCRIPTION
Hifiberry Digi is an output only card. In order to get it working I needed to add `-P` to the alsa parameters of the command. This tells jackd to only use playback ports.

> -P, --playback [ name ]
Provide only playback ports, unless combined with -D or -C. Optionally set playback device name.
from [jackd manual](https://linux.die.net/man/1/jackd)