### PR TITLE
Removed hyphen

### DIFF
--- a/templates/reboot_block.html
+++ b/templates/reboot_block.html
@@ -5,7 +5,7 @@
 <br>
 <br>
 <img src="/img/loading.gif">
-<b>Re-starting system (refreshing page in 20 seconds)...</b>
+<b>Restarting system (refreshing page in 20 seconds)...</b>
 <br>
 <br>
 <br>


### PR DESCRIPTION
'Restarting' reads far more naturally than 're-starting'. :- )