### PR TITLE
Add Pi 7 Touchscreen display and fix jack pisound cfg

### DIFF
--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -98,7 +98,7 @@ soundcard_presets = OrderedDict([
 	}],
 	['PiSound', {
 		'SOUNDCARD_CONFIG': 'dtoverlay=pisound',
-		'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:0 -r 44100 -p 256 -n 2 -X raw',
+		'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:pisound -r 44100 -p 256 -n 2 -X raw',
 		'SOUNDCARD_MIXER': ''
 	}],
 	['JustBoom DAC', {

--- a/lib/display_config_handler.py
+++ b/lib/display_config_handler.py
@@ -245,6 +245,14 @@ class DisplayConfigHandler(ZynthianConfigHandler):
 			'DISPLAY_HEIGHT': '320',
 			'FRAMEBUFFER': '/dev/fb1'
 		}],
+                ['Pi 7 Touchscreen Display 800x480', {
+                        'DISPLAY_CONFIG':
+                                'lcd_rotate=2\n'+
+                                'dtoverlay=rpi-ft5406\n',
+                        'DISPLAY_WIDTH': '800',
+                        'DISPLAY_HEIGHT': '480',
+                        'FRAMEBUFFER': '/dev/fb0'
+                }],
 		['Generic HDMI Display', {
 			'DISPLAY_CONFIG': 'disable_overscan=1\n',
 			'DISPLAY_WIDTH': '',


### PR DESCRIPTION
This patch adds the new Rpi 7" Touchscreen Display as a selectable
option to the webgui and changes the jack config line for pisound
devices from hw:0 to hw:pisound.