### PR TITLE
Use different config for onscreen buttons and touch widgets.

### DIFF
--- a/lib/ui_config_handler.py
+++ b/lib/ui_config_handler.py
@@ -114,6 +114,11 @@ class UiConfigHandler(ZynthianConfigHandler):
 				'title': 'Mixer settings on snapshots',
 				'value': os.environ.get('ZYNTHIAN_UI_SNAPSHOT_MIXER_SETTINGS', '0')
 			}],
+			['ZYNTHIAN_UI_ONSCREEN_BUTTONS', {
+				'type': 'boolean',
+				'title': 'Enable Onscreen Buttons',
+				'value': os.environ.get('ZYNTHIAN_UI_ONSCREEN_BUTTONS', '0'),
+			}],
 			['ZYNTHIAN_UI_TOUCH_WIDGETS', {
 				'type': 'boolean',
 				'title': 'Enable Touch Widgets',
@@ -135,6 +140,7 @@ class UiConfigHandler(ZynthianConfigHandler):
 		self.request.arguments['ZYNTHIAN_UI_SNAPSHOT_MIXER_SETTINGS'] = self.request.arguments.get('ZYNTHIAN_UI_SNAPSHOT_MIXER_SETTINGS', '0')
 		self.request.arguments['ZYNTHIAN_UI_RESTORE_LAST_STATE'] = self.request.arguments.get('ZYNTHIAN_UI_RESTORE_LAST_STATE', '0')
 		self.request.arguments['ZYNTHIAN_UI_ENABLE_CURSOR'] = self.request.arguments.get('ZYNTHIAN_UI_ENABLE_CURSOR', '0')
+		self.request.arguments['ZYNTHIAN_UI_ONSCREEN_BUTTONS'] = self.request.arguments.get('ZYNTHIAN_UI_ONSCREEN_BUTTONS', '0')
 		self.request.arguments['ZYNTHIAN_UI_TOUCH_WIDGETS'] = self.request.arguments.get('ZYNTHIAN_UI_TOUCH_WIDGETS', '0')
 
 		escaped_arguments = tornado.escape.recursive_unicode(self.request.arguments)


### PR DESCRIPTION
This adds an extra configuration element to the ui-options page for onscree buttons. This allows separate configuration of onscreen buttons (4 buttons at bottom of screen representing encoder switches, better on smaller screens) and touchscreen widgests (extra onscreen controls that provide enhanced touch interface, better on larger screens).

The current common use of onscreen widgets to enable onscreen buttons will change so users will need to change their configuration but this seems a better use of the configurations and few users are currently using this feature. It will be immediately obvious that the change has occured to those affected and the default is OFF so they will already be familiar with enabling the feature.

This PR should be applied before merging zynseq to zyngui. It can (should) be does not depend on zynseq and allows for users to experience changes nmore gradually, i.e. they change their onscreen config now and then can experience the zynseq change with less distraction!