### PR TITLE
Wire config labels to form controls

### DIFF
--- a/templates/backup.html
+++ b/templates/backup.html
@@ -1,5 +1,5 @@
 <div class="pull-right">
-        <input id="check_advanced_view" type="checkbox" onChange="onchange_check_advanced_view()"/><span>Advanced view</span>
+        <input id="check_advanced_view" type="checkbox" onChange="onchange_check_advanced_view()"/><span><label for="check_advanced_view">Advanced view</label></span>
 </div>
 
 <h2>{{ title }}</h2>

--- a/templates/config_block.html
+++ b/templates/config_block.html
@@ -2,7 +2,7 @@
 {% autoescape None %}
 
 <div class="pull-right">
-	<input id="check_advanced_view" type="checkbox" onChange="onchange_check_advanced_view()"/><span>Advanced view</span>
+	<input id="check_advanced_view" type="checkbox" onChange="onchange_check_advanced_view()"/><span><label for="check_advanced_view">Advanced view</label></span>
 </div>
 
 <h2>{{ escape(title) }}</h2>
@@ -28,7 +28,7 @@
 	<div class="{{ div_class }}" {% try %} {{ "root_var=\"{}\"".format(config[varname]['root_var']) }} {% except %} {% end %} {% try %} {{ "enabling_options=\"{}\"".format(config[varname]['enabling_options']) }} {% except %} {% end %}>
 
 		{% if config[varname]['type'] not in ['button', 'hidden', 'html', 'jscript'] %}
-			<label>{{ escape(config[varname]['title']) }}:</label>
+			<label for="{{ escape(config[varname]) }}">{{ escape(config[varname]['title']) }}:</label>
 			{% if config[varname]['type'] != 'boolean' %} <br>{% end %}
 		{% end %}
 


### PR DESCRIPTION
I'm just getting started poking around with the Zynthian.

I noticed that many of the form controls are not clickable.

I don't see instructions on running the webconf locally / developing, so I'm shooting in the dark a bit on this; further instructions on the development process would be welcome.

This PR adds targets to the two `Advanced view` labels used in the webconf; the one on the backups screen, and the generic one used in the config_block template.

Adding the `for` attribute to the existing `label` tags should allow pressing on any part of the label to activate the associate input.

https://user-images.githubusercontent.com/7367/111080718-0a371700-84bd-11eb-8be3-872748d06bf0.mov
