### PR TITLE
Fixes bug #494. Convert string to float then int.

### DIFF
--- a/lib/zynthian_config_handler.py
+++ b/lib/zynthian_config_handler.py
@@ -94,7 +94,7 @@ class ZynthianBasicHandler(tornado.web.RequestHandler):
 			info['novnc1_uri']="http://{}:6081/vnc.html".format(self.request.host)
 
 		# Restore scroll position
-		info['scrollTop'] = int(self.get_argument('_scrollTop', '0'))
+		info['scrollTop'] = int(float(self.get_argument('_scrollTop', '0')))
 
 		super().render(tpl, info=info, **kwargs)
 


### PR DESCRIPTION
Under some conditions a web page will return a floating point value for its top. This is returned as a string by the underlying library. Previous implementation attempted to convert this directly to an integer which would sometimes fail. Adding the extra conversion to a float before converting to an integer resolves the issue. 