### PR TITLE
updated Display to support Ili9486 3.5 LCD default to 270 rotation

### DIFF
--- a/lib/display_config_handler.py
+++ b/lib/display_config_handler.py
@@ -71,6 +71,12 @@ class DisplayConfigHandler(ZynthianConfigHandler):
 			'DISPLAY_HEIGHT': '320',
 			'FRAMEBUFFER': '/dev/fb1'
 		}],
+		['Ili9486 3.5 (v1)', {
+			'DISPLAY_CONFIG': 'dtoverlay=tft35a:rotate=270',
+			'DISPLAY_WIDTH': '480',
+			'DISPLAY_HEIGHT': '320',
+			'FRAMEBUFFER': '/dev/fb1'
+        }],
 		['PiTFT 2.8 Resistive', {
 			'DISPLAY_CONFIG': 'dtoverlay=pitft28-resistive,rotate=90,speed=32000000,fps=20',
 			'DISPLAY_WIDTH': '320',


### PR DESCRIPTION
Updated Display to support Ili9486 3.5 LCD default to 270 rotation.

Touch controller: XPT2046 (ADS7846)
Display controller: ILI 9486

Confirmed working on Raspberry Pi 4 Model B Rev 1.2.

Correlated overlay and config pull request available [here.](https://github.com/zynthian/zynthian-sys/pull/205/)