### PR TITLE
Add Tascam US-2x2HR USB interface

### DIFF
--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -214,6 +214,11 @@ soundcard_presets = {
 		'JACKD_OPTIONS': '-P 70 -s -d alsa -d hw:Microphone -r 48000 -p 256 -n 2 -X raw',
 		'SOUNDCARD_MIXER': 'Speaker Left,Mic Left,Speaker Right,Mic Right'
 	},
+	'Tascam US-2x2HR': {
+		'SOUNDCARD_CONFIG': '',
+		'JACKD_OPTIONS': '-P 70 -t 2000 -s -d alsa -d hw:US2x2HR -r 48000 -p 256 -n 2 -X raw',
+		'SOUNDCARD_MIXER': ''
+	},
 	'RBPi Headphones': {
 		'SOUNDCARD_CONFIG': 'dtparam=audio=on\naudio_pwm_mode=2',
 		'JACKD_OPTIONS': '-P 70 -s -d alsa -d hw:#DEVNAME# -r 48000 -o 2 -p 512 -n 3 -X raw',


### PR DESCRIPTION
Added with a samplerate of 48000. Because all presets now have that samplerate. But out of the box the unit is set to have a samplerate of 44100.

One can change the samplerate of the interface via a Windows machine with mmsys.cpl to 48000 (it supports samplerates up to 192000).

Or use -r 44100 instead. I do not know whether it is possible to change its settings via Linux, but changing the rate to something else in jackd just means you'll get a non-working system.