### PR TITLE
Bug/1358 iq audio pro not configurable from webconf

### DIFF
--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -140,7 +140,7 @@ soundcard_presets = {
         'SOUNDCARD_MIXER': ''
     },
     'IQAudio DAC Pro': {
-        'SOUNDCARD_CONFIG': 'dtoverlay=iqaudio-dacplus',
+        'SOUNDCARD_CONFIG': 'dtoverlay=iqaudio-dac',
         'JACKD_OPTIONS': f"-P 70 -s -S -d alsa -d hw:Pro {default_i2s_bufreq_config} -o 2 -X raw",
         'SOUNDCARD_MIXER': ''
     },

--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -139,7 +139,7 @@ soundcard_presets = {
         'JACKD_OPTIONS': f"-P 70 -s -S -d alsa -d hw:IQaudIODAC {default_i2s_bufreq_config} -o 2 -X raw",
         'SOUNDCARD_MIXER': ''
     },
-    'IQAudio DAC+': {
+    'IQAudio DAC Pro': {
         'SOUNDCARD_CONFIG': 'dtoverlay=iqaudio-dacplus',
         'JACKD_OPTIONS': f"-P 70 -s -S -d alsa -d hw:Pro {default_i2s_bufreq_config} -o 2 -X raw",
         'SOUNDCARD_MIXER': ''

--- a/lib/audio_config_handler.py
+++ b/lib/audio_config_handler.py
@@ -139,6 +139,11 @@ soundcard_presets = {
         'JACKD_OPTIONS': f"-P 70 -s -S -d alsa -d hw:IQaudIODAC {default_i2s_bufreq_config} -o 2 -X raw",
         'SOUNDCARD_MIXER': ''
     },
+    'IQAudio DAC+': {
+        'SOUNDCARD_CONFIG': 'dtoverlay=iqaudio-dacplus',
+        'JACKD_OPTIONS': f"-P 70 -s -S -d alsa -d hw:Pro {default_i2s_bufreq_config} -o 2 -X raw",
+        'SOUNDCARD_MIXER': ''
+    },
     'IQAudio Digi': {
         'SOUNDCARD_CONFIG': 'dtoverlay=iqaudio-digi-wm8804-audio',
         'JACKD_OPTIONS': f"-P 70 -s -S -d alsa -d hw:0 {default_i2s_bufreq_config} -o 2 -X raw",


### PR DESCRIPTION
https://github.com/zynthian/zynthian-issue-tracking/issues/1358

Allows the selection of the IQ Audio DAC Pro as a soundcard from webconf without the need to manually fiddle with the settings