### PR TITLE
Fixes 404 error for User Soundfonts link on Webconf homepage

### DIFF
--- a/lib/dashboard_handler.py
+++ b/lib/dashboard_handler.py
@@ -202,7 +202,7 @@ class DashboardHandler(ZynthianBasicHandler):
                     'USER_SOUNDFONTS': {
                         'title': 'User Soundfonts',
                         'value': str(self.get_num_of_files(os.environ.get('ZYNTHIAN_MY_DATA_DIR')+"/soundfonts")),
-                        'url': "/lib-soundfont"
+                        'url': "/lib-presets"
                     },
                     'AUDIO_CAPTURES': {
                         'title': 'Audio Captures',


### PR DESCRIPTION
Now links to combined Presets & Soundfonts page

Fixes 
https://github.com/zynthian/zynthian-issue-tracking/issues/1098 
https://github.com/zynthian/zynthian-issue-tracking/issues/1641 (duplicate)

Discussion
https://discourse.zynthian.org/t/webinterface-soundfont-link-produces-404/11363