### PR TITLE
Fix: Hide expand/collapse when no extended package description

### DIFF
--- a/templates/extra_packs.html
+++ b/templates/extra_packs.html
@@ -92,8 +92,10 @@ div.package div.description p {
 				</div>
 				<div class="description">
 					<p>{% raw info['description'] %}
+					{% if info['description_extended'] %}
 						<a class="read_more" href="javascript:expand_description('pack_{{ _pack_name }}')">[+]</a>
 						<a class="read_less" href="javascript:collapse_description('pack_{{ _pack_name }}')">[-]</a>
+					{% end %}
 					</p>
 					<div class="extended">
 					{% raw info['description_extended'] %}


### PR DESCRIPTION
Fixes https://github.com/zynthian/zynthian-issue-tracking/issues/1679