### PR TITLE
display: add Raspberry Pi Touch Display 2 (7") option + 90/270 rotation

### DIFF
--- a/lib/display_config_handler.py
+++ b/lib/display_config_handler.py
@@ -404,6 +404,16 @@ class DisplayConfigHandler(ZynthianConfigHandler):
             'DISPLAY_KERNEL_OPTIONS': 'video=DSI-1:800x480@60,rotate=180',
             'FRAMEBUFFER': '/dev/fb0'
         },
+        'Raspberry Pi Touch Display 2 (7 inch)': {
+            'DISPLAY_CONFIG':
+                'disable_overscan=1\n' +
+                'dtoverlay=vc4-kms-dsi-ili9881-7inch\n',
+            'DISPLAY_WIDTH': '1280',
+            'DISPLAY_HEIGHT': '720',
+            'DISPLAY_ROTATION': "Right",
+            'DISPLAY_KERNEL_OPTIONS': '',
+            'FRAMEBUFFER': '/dev/fb0'
+        },
         'MIPI DSI 800x480': {
             'DISPLAY_CONFIG': '',
             'DISPLAY_WIDTH': '800',
@@ -499,9 +509,15 @@ class DisplayConfigHandler(ZynthianConfigHandler):
         }
         config['DISPLAY_ROTATION'] = {
             'type': 'select',
-            'title': "Touch Rotation",
+            'title': "Display Rotation",
             'value': str(os.environ.get('DISPLAY_ROTATION')),
-            'options': ["None", "Inverted"],
+            'options': ["None", "Right", "Inverted", "Left"],
+            'option_labels': {
+                'None': "None (0\u00b0)",
+                'Right': "Right (90\u00b0)",
+                'Inverted': "Inverted (180\u00b0)",
+                'Left': "Left (270\u00b0)",
+            },
             'disabled': custom_options_disabled
         }
         config['DISPLAY_KERNEL_OPTIONS'] = {


### PR DESCRIPTION
# display: add Raspberry Pi Touch Display 2 (7″) option + 90°/270° rotation in the UI

**Base:** `zynthian/zynthian-webconf:vangelis`
**Part of a set:** pairs with a `zynthian-sys` PR (X11 screen rotation) and builds on `zynthian/zynthian-ui#580` (touch rotation). Links below.

## What this adds

1. **A "Raspberry Pi Touch Display 2 (7″)" display preset**, defaulting to landscape. Selecting it sets the values verified on a real Pi 5 + TD2 unit:

   ```
   DISPLAY_CONFIG:  disable_overscan=1
                    dtoverlay=vc4-kms-dsi-ili9881-7inch
   DISPLAY_WIDTH:   1280
   DISPLAY_HEIGHT:  720
   DISPLAY_ROTATION: Right
   DISPLAY_KERNEL_OPTIONS: (empty)
   FRAMEBUFFER:     /dev/fb0
   ```

   The TD2 is a portrait-native panel (720×1280, `ili9881`, Goodix `gt911` touch); these values bring it up in landscape. Rotation is handled via `DISPLAY_ROTATION=Right` (touch in `zynthian-ui`, screen in `zynthian-sys`) rather than an overlay rotate param, which is inert for this panel on the current KMS stack.

2. **`Right` and `Left` options in the rotation dropdown**, so 90°/270° are selectable in the UI instead of requiring a hand-edited env var.

3. **Renamed the dropdown title "Touch Rotation" → "Display Rotation".** With the paired `zynthian-sys` change, `DISPLAY_ROTATION` now rotates both touch and screen, so the touch-only label was no longer accurate. This is a deliberate consequence of keying screen rotation off `DISPLAY_ROTATION`; if you'd rather keep the variable touch-scoped (and the old label), say so and I'll revert both this and the sys keying.

## Dependencies

- The preset's `DISPLAY_ROTATION=Right` only rotates the **screen** once the `zynthian-sys` PR lands, and only rotates **touch** once zynthian/zynthian-ui#580 lands. Until both merge, selecting the preset sets the values but full landscape behaviour isn't active.
- Additive otherwise: no existing preset is changed, so this hurts nobody who doesn't select it.

## Notes

- Only a landscape (`Right`) preset is added. Other mountings (portrait, 270°) are reachable by changing the rotation dropdown, though portrait would also want the width/height swapped — left out to keep this focused; easy to add a variant if wanted.

## Related

- zynthian-ui: zynthian/zynthian-ui#580 (touch-side 90°/270° rotation)
- zynthian-sys: github.com/zynthian/zynthian-sys/pull/224 (X11 screen rotation via DISPLAY_ROTATION)
